### PR TITLE
Added support for batch create requests

### DIFF
--- a/lib/restapi.js
+++ b/lib/restapi.js
@@ -126,7 +126,7 @@ export default class RestApi {
     return this.request.post(
       _.merge(
         {
-          url: `/${options.type}/create`,
+          url: options.type === 'batch' ? `/batch` : `/${options.type}/create`,
           json: postBody
         },
         options.requestOptions,


### PR DESCRIPTION
Rally webservice API v2.0 supports bulk POST requests to the `/batch` endpoint. I added support for batch type requests in the create method.